### PR TITLE
Refresh CI baseline and supported tooling stack

### DIFF
--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
 
@@ -23,6 +23,6 @@ jobs:
         uses: aglipanci/laravel-pint-action@2.6
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v6
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: Fix styling

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,28 +1,43 @@
 name: PHPStan
 
 on:
-  push:
-    paths:
-      - '**.php'
-      - 'phpstan.neon.dist'
-      - '.github/workflows/phpstan.yml'
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   phpstan:
     name: phpstan
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: "8.4"
           coverage: none
 
+      - name: Validate composer
+        run: composer validate --no-check-publish
+
       - name: Install composer dependencies
-        uses: ramsey/composer-install@v3
+        run: |
+          composer require --dev \
+            "laravel/framework:12.*" \
+            "orchestra/testbench:^10.9.0" \
+            "pestphp/pest:^3.8.4" \
+            "pestphp/pest-plugin-laravel:^3.2.0" \
+            "pestphp/pest-plugin-arch:^3.1.1" \
+            "larastan/larastan:^3.9.2" \
+            "phpstan/phpstan:^2.1.32" \
+            "phpstan/phpstan-phpunit:^2.0.7" \
+            "phpstan/phpstan-deprecation-rules:^2.0.3" \
+            --no-interaction --no-update
+          composer update --prefer-dist --no-interaction
 
       - name: Run PHPStan
-        run: ./vendor/bin/phpstan --error-format=github
+        run: ./vendor/bin/phpstan analyse --no-progress --error-format=github

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -37,7 +37,7 @@ jobs:
             "phpstan/phpstan-phpunit:^2.0.7" \
             "phpstan/phpstan-deprecation-rules:^2.0.3" \
             --no-interaction --no-update
-          composer update --prefer-dist --no-interaction
+          composer update -W --prefer-dist --no-interaction
 
       - name: Run PHPStan
         run: ./vendor/bin/phpstan analyse --no-progress --error-format=github

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,64 +1,84 @@
 name: run-tests
 
 on:
-  push:
-    branches: [main]
   pull_request:
-    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest]
-        php: [8.3]
-        laravel: [11.*]
-        stability: [prefer-stable]
         include:
-          - laravel: 11.*
-            testbench: 9.*
-            carbon: ^2.63
+          - php: "8.1"
+            laravel: "10.*"
+            testbench: "^8.22.0"
+            pest: "^2.34.7"
+            pest_plugin_laravel: "^2.4.0"
+            pest_plugin_arch: "^2.7.0"
+            larastan: "^2.11.2"
+            phpstan: "^1.12.17"
+            phpstan_phpunit: "^1.4.2"
+            phpstan_deprecation_rules: "^1.2.1"
+          - php: "8.2"
+            laravel: "11.*"
+            testbench: "^9.17.0"
+            pest: "^3.8.4"
+            pest_plugin_laravel: "^3.2.0"
+            pest_plugin_arch: "^3.1.1"
+            larastan: "^3.9.2"
+            phpstan: "^2.1.32"
+            phpstan_phpunit: "^2.0.7"
+            phpstan_deprecation_rules: "^2.0.3"
+          - php: "8.4"
+            laravel: "12.*"
+            testbench: "^10.9.0"
+            pest: "^3.8.4"
+            pest_plugin_laravel: "^3.2.0"
+            pest_plugin_arch: "^3.1.1"
+            larastan: "^3.9.2"
+            phpstan: "^2.1.32"
+            phpstan_phpunit: "^2.0.7"
+            phpstan_deprecation_rules: "^2.0.3"
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
-          coverage: xdebug
+          coverage: none
 
-      - name: Setup problem matchers
-        run: |
-          echo "::add-matcher::${{ runner.tool_cache }}/php.json"
-          echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+      - name: Validate composer
+        run: composer validate --no-check-publish
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" --no-interaction --no-update
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+          composer require --dev \
+            "laravel/framework:${{ matrix.laravel }}" \
+            "orchestra/testbench:${{ matrix.testbench }}" \
+            "pestphp/pest:${{ matrix.pest }}" \
+            "pestphp/pest-plugin-laravel:${{ matrix.pest_plugin_laravel }}" \
+            "pestphp/pest-plugin-arch:${{ matrix.pest_plugin_arch }}" \
+            "larastan/larastan:${{ matrix.larastan }}" \
+            "phpstan/phpstan:${{ matrix.phpstan }}" \
+            "phpstan/phpstan-phpunit:${{ matrix.phpstan_phpunit }}" \
+            "phpstan/phpstan-deprecation-rules:${{ matrix.phpstan_deprecation_rules }}" \
+            --no-interaction --no-update
+          composer update --prefer-dist --no-interaction
 
       - name: List Installed Dependencies
         run: composer show -D
 
-      - name: Setup Code Climate
-        uses: amancevice/setup-code-climate@v2
-        with:
-          cc_test_reporter_id: ${{ secrets.CC_TEST_REPORTER_ID }}
-
-      - name: Install Code Climate Test Reporter
-        run: cc-test-reporter before-build
-
       - name: Run Tests
-        run: |
-          vendor/bin/pest --coverage-clover clover.xml
-
-      - name: Upload coverage reports to Code Climate
-        run: |
-          cc-test-reporter after-build
+        run: composer test

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - php: "8.1"
+          - php: "8.2"
             laravel: "10.*"
             testbench: "^8.22.0"
             pest: "^2.34.7"
@@ -75,7 +75,7 @@ jobs:
             "phpstan/phpstan-phpunit:${{ matrix.phpstan_phpunit }}" \
             "phpstan/phpstan-deprecation-rules:${{ matrix.phpstan_deprecation_rules }}" \
             --no-interaction --no-update
-          composer update --prefer-dist --no-interaction
+          composer update -W --prefer-dist --no-interaction
 
       - name: List Installed Dependencies
         run: composer show -D

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
 
@@ -25,7 +25,7 @@ jobs:
           release-notes: ${{ github.event.release.body }}
 
       - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v6
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           branch: main
           commit_message: Update CHANGELOG

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 [![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/the-3labs-team/laravel-keyword-linker/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/the-3labs-team/laravel-keyword-linker/actions?query=workflow%3Arun-tests+branch%3Amain)
 [![Github PHPStan](https://img.shields.io/github/actions/workflow/status/the-3labs-team/laravel-keyword-linker/phpstan.yml?branch=main&label=phpstan&style=flat-square)](https://github.com/the-3labs-team/laravel-keyword-linker/actions?query=workflow%3Aphpstan+branch%3Amain)
 [![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/the-3labs-team/laravel-keyword-linker/fix-php-code-style-issues.yml?branch=main&label=code%20style&style=flat-square)](https://github.com/the-3labs-team/laravel-keyword-linker/actions?query=workflow%3A"Fix+PHP+code+style+issues"+branch%3Amain)
-[![Maintainability](https://api.codeclimate.com/v1/badges/6ad969baa15a372e264e/maintainability)](https://codeclimate.com/github/The-3Labs-Team/laravel-keyword-linker/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/6ad969baa15a372e264e/test_coverage)](https://codeclimate.com/github/The-3Labs-Team/laravel-keyword-linker/test_coverage)
 ![License Mit](https://img.shields.io/github/license/murdercode/laravel-shortcode-plus)
 [![Total Downloads](https://img.shields.io/packagist/dt/the-3labs-team/laravel-keyword-linker.svg?style=flat-square)](https://packagist.org/packages/the-3labs-team/laravel-keyword-linker)
 
@@ -15,17 +13,15 @@ This is a package that converts keywords into links.
 
 | Package Version     | Requirement | Version             |
 |---------------------|-------------|---------------------|
-| 1.x.x               | Laravel     | 10.x or 11.x        |
-| 1.x.x               | Nova        | 4.x                 |
-| dev-beta-laravel-12 | Laravel     | 12.x                |
-| dev-beta-laravel-12 | Nova        | 5.x                 |
+| 1.x.x               | PHP         | 8.1, 8.2, 8.3 or 8.4 |
+| 1.x.x               | Laravel     | 10.x, 11.x or 12.x |
 
 ## Installation
 
 You can install the package via composer:
 
 ```bash
-composer install the-3labs-team/keyword-linker
+composer require the-3labs-team/laravel-keyword-linker
 ```
 
 You can publish the config file with:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a package that converts keywords into links.
 
 | Package Version     | Requirement | Version             |
 |---------------------|-------------|---------------------|
-| 1.x.x               | PHP         | 8.1, 8.2, 8.3 or 8.4 |
+| 1.x.x               | PHP         | 8.2, 8.3 or 8.4 |
 | 1.x.x               | Laravel     | 10.x, 11.x or 12.x |
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.1|^8.2|^8.3|^8.4",
+        "php": "^8.2|^8.3|^8.4",
         "spatie/laravel-package-tools": "^1.16",
         "illuminate/contracts": "^10.0||^11.0||^12.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -23,14 +23,15 @@
     "require-dev": {
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.1.1||^7.10.0",
-        "larastan/larastan": "^2.9",
-        "orchestra/testbench": "^9.0.0||^8.22.0",
-        "pestphp/pest": "^2.34",
-        "pestphp/pest-plugin-arch": "^2.7",
-        "pestphp/pest-plugin-laravel": "^2.3",
-        "phpstan/extension-installer": "^1.3",
-        "phpstan/phpstan-deprecation-rules": "^1.1",
-        "phpstan/phpstan-phpunit": "^1.3"
+        "larastan/larastan": "^2.11.2||^3.9",
+        "orchestra/testbench": "^8.22.0||^9.17.0||^10.9",
+        "pestphp/pest": "^2.34.7||^3.8",
+        "pestphp/pest-plugin-arch": "^2.7||^3.1",
+        "pestphp/pest-plugin-laravel": "^2.4||^3.2",
+        "phpstan/extension-installer": "^1.4",
+        "phpstan/phpstan": "^1.12.17||^2.1.32",
+        "phpstan/phpstan-deprecation-rules": "^1.2.1||^2.0.3",
+        "phpstan/phpstan-phpunit": "^1.4.2||^2.0.7"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
- replace the fragile test workflow with a small pull-request CI baseline
- align tooling constraints for Laravel 10, 11, and 12 support
- tighten declared PHP support to 8.2+
- absorb the pending major GitHub Actions dependency bumps into the repository baseline
- fix README support and installation notes

## What changed
- `run-tests.yml` now runs on `pull_request` and `workflow_dispatch` only
- the test matrix now verifies Laravel 10 / 11 / 12 with coherent Testbench, Pest, Larastan, and PHPStan versions
- the repository now declares PHP `^8.2|^8.3|^8.4` instead of keeping an untested PHP 8.1 claim alive
- `phpstan.yml` now runs on pull requests and installs the Laravel 12-compatible analysis stack directly
- `actions/checkout` was updated to `v6`
- `stefanzweifel/git-auto-commit-action` was updated to `v7`
- the old Code Climate coupling was removed from CI so dependency PRs are not blocked by external coverage setup
- `composer.json` now declares compatible ranges for the supported Laravel branches
- `README.md` now documents Laravel 10 / 11 / 12 support and the correct Composer install command

## Local verification
- `composer test` with Laravel 10.50.2 / Testbench 8.37.0 / Pest 2.36.1
- `composer test` with Laravel 11.50.0 / Testbench 9.17.0 / Pest 3.8.6
- `composer test` with Laravel 12.55.1 / Testbench 10.11.0 / Pest 3.8.6
- `vendor/bin/phpstan analyse --debug --no-progress` with Laravel 12.55.1 / Larastan 3.9.3 / PHPStan 2.1.44

## Notes
- this PR supersedes the current major Dependabot PRs for `actions/checkout`, `stefanzweifel/git-auto-commit-action`, and `ramsey/composer-install`
- repository-level `Allow auto-merge` still needs to be verified manually if you want Dependabot auto-merge to work end to end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added PHP 8.4 support and expanded Laravel 12 compatibility.
  * Updated CI workflows to run on pull requests, simplified test matrix, and upgraded CI tooling.
  * Updated development dependencies for broader version compatibility; test and analysis tooling upgraded.
* **Documentation**
  * Removed Code Climate badges and updated installation instructions to the package require form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->